### PR TITLE
WDP220101-4

### DIFF
--- a/src/components/common/ProductBox/ProductBox.module.scss
+++ b/src/components/common/ProductBox/ProductBox.module.scss
@@ -29,7 +29,7 @@
     }
 
     .buttons {
-      display: flex;
+      display: none;
       justify-content: space-between;
     }
   }
@@ -74,5 +74,11 @@
     display: flex;
     justify-content: space-between;
     align-items: center;
+  }
+
+  &:hover {
+    .buttons {
+      display: flex;
+    }
   }
 }


### PR DESCRIPTION
Buttons Add to Cart and Quick view were visible all the time on the Product Box.
Hover effect was added and now only after hover the particular Product Box, those Buttons are visible.