### PR TITLE
WDP220101-2

### DIFF
--- a/src/components/layout/CompanyClaim/CompanyClaim.js
+++ b/src/components/layout/CompanyClaim/CompanyClaim.js
@@ -26,7 +26,7 @@ const CompanyClaim = () => (
             <div className={styles.cartIcon}>
               <FontAwesomeIcon className={styles.icon} icon={faShoppingBasket} />
             </div>
-            <div className={styles.cartCounter}>0</div>
+            <div className={styles.cartCounter}>12345</div>
           </a>
         </div>
       </div>

--- a/src/components/layout/CompanyClaim/CompanyClaim.module.scss
+++ b/src/components/layout/CompanyClaim/CompanyClaim.module.scss
@@ -47,19 +47,20 @@
       }
 
       .cartCounter {
-        width: 28px;
+        width: 50px;
         height: 27px;
         border-radius: 14px;
         background-color: $header-bg;
         display: flex;
         align-items: center;
-        justify-content: center;
+        padding-left: 15%;
+        justify-content: left;
         font-size: 14px;
         color: rgb(224, 227, 237);
         position: absolute;
         top: 50%;
         right: 0;
-        transform: translate(50%, -50%);
+        transform: translate(75%, -50%);
       }
 
       &:hover {


### PR DESCRIPTION
Opis problemu: Przy wyświetlaniu większej liczby np. 123 element źle się zachowuje. Poprawić tak, aby pozwalał na wyświetlanie liczb z zakresu 0-99999 (max. 5 cyfr).

Rozwiązanie: zmiana stylów elementu .cartCounter
- zwiększenie width
- transform translate oś x - zmiana z 50% na 75%
- dodanie padding-left: 15%;
- zmiana justify-content: center na left