### PR TITLE
WDP220101-13 Swipeable - obsługa swipe

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "bootstrap": "^4.3.1",
     "enzyme": "^3.10.0",
     "enzyme-adapter-react-16": "^1.14.0",
+    "lodash": "^4.17.21",
     "node-sass": "^4.14.0",
     "npm-run-all": "^4.1.5",
     "prop-types": "^15.7.2",
@@ -61,6 +62,7 @@
     "react-redux": "^7.1.1",
     "react-router-dom": "^5.1.2",
     "react-scripts": "3.1.2",
+    "react-swipeable-views": "^0.14.0",
     "react-test-renderer": "^16.9.0",
     "redux": "^4.0.4"
   },

--- a/src/components/features/NewFurniture/NewFurniture.js
+++ b/src/components/features/NewFurniture/NewFurniture.js
@@ -1,5 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import SwipeableViews from 'react-swipeable-views';
+import * as _ from 'lodash';
 
 import styles from './NewFurniture.module.scss';
 import ProductBox from '../../common/ProductBox/ProductBox';
@@ -9,11 +11,20 @@ class NewFurniture extends React.Component {
   state = {
     activePage: 0,
     activeCategory: 'bed',
+    rwdMode: 'desktop',
   };
 
   handlePageChange(newPage) {
-    this.setState({ activePage: newPage });
+    this.setState({
+      activePage: newPage,
+    });
   }
+
+  handleChangeIndex = activePage => {
+    this.setState({
+      activePage,
+    });
+  };
 
   handleCategoryChange(newCategory) {
     this.setState({ activeCategory: newCategory });
@@ -21,10 +32,16 @@ class NewFurniture extends React.Component {
 
   render() {
     const { categories, products, assignFavourite, assignCompare } = this.props;
-    const { activeCategory, activePage } = this.state;
+    const { activeCategory, activePage, rwdMode } = this.state;
+
+    const productsPerPage = () =>
+      (rwdMode === 'desktop' && 8) ||
+      (rwdMode === 'tablet' && 6) ||
+      (rwdMode === 'mobile' && 1);
 
     const categoryProducts = products.filter(item => item.category === activeCategory);
-    const pagesCount = Math.ceil(categoryProducts.length / 8);
+    const renderProductsArr = _.chunk(categoryProducts, productsPerPage());
+    const pagesCount = Math.ceil(categoryProducts.length / productsPerPage());
     const actions = { assignFavourite, assignCompare };
 
     const getCompareProductAmount = () =>
@@ -66,22 +83,34 @@ class NewFurniture extends React.Component {
                   ))}
                 </ul>
               </div>
-              <div className={'col-auto ' + styles.dots}>
+              <div
+                className={
+                  'col-auto ' + (rwdMode === 'mobile' ? styles.noDots : styles.dots)
+                }
+              >
                 <ul>{dots}</ul>
               </div>
             </div>
           </div>
-          <div className='row'>
-            {categoryProducts.slice(activePage * 8, (activePage + 1) * 8).map(item => (
-              <div key={item.id} className='col col-12 col-md-4 col-lg-3'>
-                <ProductBox
-                  {...item}
-                  actions={actions}
-                  compareAmount={getCompareProductAmount()}
-                />
+          <SwipeableViews
+            index={activePage}
+            onChangeIndex={this.handleChangeIndex}
+            enableMouseEvents
+          >
+            {renderProductsArr.map((renderProducts, index) => (
+              <div key={`swipe-${index}`} className='row '>
+                {renderProducts.map(item => (
+                  <div key={item.id} className='col col-12 col-md-4 col-lg-3'>
+                    <ProductBox
+                      {...item}
+                      actions={actions}
+                      compareAmount={getCompareProductAmount()}
+                    />
+                  </div>
+                ))}
               </div>
             ))}
-          </div>
+          </SwipeableViews>
           <div className='row'>
             <CompareBar />
           </div>

--- a/src/components/features/NewFurniture/NewFurniture.module.scss
+++ b/src/components/features/NewFurniture/NewFurniture.module.scss
@@ -105,5 +105,9 @@
         }
       }
     }
+
+    .noDots {
+      display: none;
+    }
   }
 }

--- a/src/components/features/Slider/Slider.js
+++ b/src/components/features/Slider/Slider.js
@@ -10,6 +10,17 @@ class Slider extends React.Component {
     lastThumbnailsNo: 6,
   };
 
+  handleThumbnailChange(event, thumbnailChange) {
+    event.preventDefault();
+    const newActiveThumbnail = this.state.activeThumbnail + thumbnailChange;
+    this.setState({
+      activeThumbnail:
+        newActiveThumbnail > -1 && newActiveThumbnail < this.state.lastThumbnailsNo
+          ? newActiveThumbnail
+          : this.state.activeThumbnail,
+    });
+  }
+
   render() {
     const { imagesURLs } = this.props;
     const { activeThumbnail, firstThumbnailsNo, lastThumbnailsNo } = this.state;
@@ -22,7 +33,10 @@ class Slider extends React.Component {
 
     return (
       <div className={styles.root}>
-        <div className={styles.leftButton} />
+        <div
+          className={styles.leftButton}
+          onClick={event => this.handleThumbnailChange(event, -1)}
+        />
         <div className={styles.thumbnails}>
           {renderImagesURLs.map((imageURL, index) => (
             <div
@@ -37,7 +51,10 @@ class Slider extends React.Component {
             </div>
           ))}
         </div>
-        <div className={styles.rightButton} />
+        <div
+          className={styles.rightButton}
+          onClick={event => this.handleThumbnailChange(event, 1)}
+        />
       </div>
     );
   }


### PR DESCRIPTION
Doinstalowałem lodash i react-swipeable-views od obsugi efektu swipe. 
W komponencie NewFurniture zwrappowałem ProductBoxy w komponent SwipeableViews.
Kliknięcie i przeciągniecie prawo/lewo myszą lub palcem zmienia aktywną stronę, tak samo jak funkcjonalność kropek.
Dodałem do state na sztywno akualny stan viewportu (jak stan viewportu będzie zapisywany  w stanie aplikacji, poprawię to).
W zależności od stanu RWD zmienia się ilość ProductBoxów generowanych na aktywnej stronie (funkcja productsPerPage).
Przy widoku mobile, jest widoczny tylko jeden ProductBox i można sobie przewijać prawo/lewo kolejne. Nie ma wyświetlają się wtedy kropki, byłoby ich za dużo.